### PR TITLE
Update to (non LIKE) query expression

### DIFF
--- a/eQuery/widgets/Enhanced Query/Widget.js
+++ b/eQuery/widgets/Enhanced Query/Widget.js
@@ -151,11 +151,11 @@ define([
             percentPlaceHolder = " '%";
             percentPlaceHolder2 = "%'";
           } else {
-            percentPlaceHolder = "";
-            percentPlaceHolder2 = "";
+            percentPlaceHolder = "'";
+            percentPlaceHolder2 = "'";
           }
           var userQueryTextExpressionTxtArea = this.myareaExpression.get("value");
-          var userQueryTextExpressionTotal = this.optionFieldSel + " " + this.optionSelectedOperatorMathMenu +
+          var userQueryTextExpressionTotal = this.optionFieldSel + " " + this.optionSelectedOperatorMathMenu + " " +
             percentPlaceHolder + userQueryTextExpressionTxtArea + percentPlaceHolder2;
 
           this.myarea.set("value",  this.myarea.get("value") + userQueryTextExpressionTotal);


### PR DESCRIPTION
Any of the queries that use anything other than LIKE were not working for me. The percent placeholders were just empty strings instead of adding quotes around the value to be queried. SO it was attr_name = value SO I changed it to give you this result: attr_name = 'value'    it can't evaluate the query if it doesn't know that is a string :)
